### PR TITLE
Agregando pruebas en PHP para las api's de cargar identidades

### DIFF
--- a/frontend/server/controllers/IdentityController.php
+++ b/frontend/server/controllers/IdentityController.php
@@ -68,17 +68,17 @@ class IdentityController extends Controller {
             // Prepare DAOs
             $identity = self::createIdentity(
                 $r['username'],
-                $r['user'],
+                $r['name'],
                 $r['password'],
                 $r['country_id'],
                 $r['state_id'],
                 $r['gender'],
-                $r['school'],
+                $r['school_name'],
                 $r['group_alias']
             );
 
             // Save in DB
-            self::saveIdentityGroup($identity, $r['username'], $r['group_alias']);
+            self::saveIdentityGroup($identity, $r['group']->group_id);
 
             DAO::transEnd();
         } catch (Exception $e) {
@@ -112,16 +112,16 @@ class IdentityController extends Controller {
                 // Prepare DAOs
                 $identity = self::createIdentity(
                     $identity['username'],
-                    $identity['user'],
+                    $identity['name'],
                     $identity['password'],
                     $identity['country_id'],
                     $identity['state_id'],
                     $identity['gender'],
-                    $identity['school'],
+                    $identity['school_name'],
                     $r['group_alias']
                 );
 
-                self::saveIdentityGroup($identity, $identity['username'], $r['group_alias']);
+                self::saveIdentityGroup($identity, $r['group']->group_id);
             }
 
             DAO::transEnd();
@@ -144,16 +144,16 @@ class IdentityController extends Controller {
      */
     private static function validateRequest(Request $r) {
         self::authenticateRequest($r);
-        if (!Authorization::isOrganizer($r['current_identity_id'])) {
+        if (!Authorization::isGroupIdentityCreator($r['current_identity_id'])) {
             throw new ForbiddenAccessException();
         }
         GroupController::validateGroup($r);
-        if (!is_array($r['identities'])) {
+        if (!is_array($r['identities']) && (!isset($r['username']) && !isset($r['name']) && !isset($r['group_alias']))) {
             throw new InvalidParameterException('parameterInvalid', 'identities');
         }
     }
 
-    public static function validateIdentity($username, $user, $gender, $aliasGroup) {
+    public static function validateIdentity($username, $name, $gender, $aliasGroup) {
         // Check group is present
         $usernameIdentity = explode(':', $username);
         if (count($usernameIdentity) != 2) {
@@ -177,10 +177,10 @@ class IdentityController extends Controller {
             throw new DuplicatedEntryInDatabaseException('usernameInUse');
         }
 
-        if (!is_null($user)) {
-            $user = trim($user);
-            Validators::isStringNonEmpty($user, 'name', true);
-            Validators::isStringOfMaxLength($user, 'name', 50);
+        if (!is_null($name)) {
+            $name = trim($name);
+            Validators::isStringNonEmpty($name, 'name', true);
+            Validators::isStringOfMaxLength($name, 'name', 50);
         }
 
         if (!is_null($gender)) {
@@ -193,7 +193,7 @@ class IdentityController extends Controller {
 
     private static function createIdentity(
         $username,
-        $user,
+        $name,
         $password,
         $countryId,
         $stateId,
@@ -201,7 +201,7 @@ class IdentityController extends Controller {
         $school,
         $aliasGroup
     ) {
-        self::validateIdentity($username, $user, $gender, $aliasGroup);
+        self::validateIdentity($username, $name, $gender, $aliasGroup);
 
         $state = SchoolController::getStateIdFromCountryAndState($countryId, $stateId);
         $schoolId = SchoolController::createSchool(trim($school), $state);
@@ -224,17 +224,16 @@ class IdentityController extends Controller {
     /**
      * Save object Identities in DB, and add user into group.
      * This function is called inside a transaction.
-     * @param Identties $identity
-     * @param $username
-     * @param $group_alias
+     * @param Identities $identity
+     * @param $groupId
      * @throws InvalidDatabaseOperationException
      */
-    private static function saveIdentityGroup(Identities $identity, $username, $group_alias) {
+    private static function saveIdentityGroup(Identities $identity, $groupId) {
         IdentitiesDAO::save($identity);
 
-        GroupController::apiAddUser(new Request([
-            'usernameOrEmail' => $username,
-            'group_alias' => $group_alias,
+        GroupsIdentitiesDAO::save(new GroupsIdentities([
+            'group_id' => $groupId,
+            'identity_id' => $identity->identity_id
         ]));
     }
 }

--- a/frontend/server/libs/Authorization.php
+++ b/frontend/server/libs/Authorization.php
@@ -20,6 +20,9 @@ class Authorization {
     // Cache for system group for support team members
     private static $support_group = null;
 
+    // Cache for system group identity creators
+    private static $group_identity_creator = null;
+
     // Administrator for an ACL.
     const ADMIN_ROLE = 1;
 
@@ -35,6 +38,9 @@ class Authorization {
     // Mentor.
     const MENTOR_ROLE = 5;
 
+    // Identity creator.
+    const IDENTITY_CREATOR_ROLE = 6;
+
     // System-level ACL.
     const SYSTEM_ACL = 1;
 
@@ -49,6 +55,9 @@ class Authorization {
 
     // Group for support team members.
     const SUPPORT_GROUP_ALIAS = 'omegaup:support';
+
+    // Group identities creators.
+    const IDENTITY_CREATOR_GROUP_ALIAS = 'omegaup:group-identity-creator';
 
     public static function canViewRun($identity_id, Runs $run) {
         if (is_null($run) || !is_a($run, 'Runs')) {
@@ -143,6 +152,10 @@ class Authorization {
         return self::isMentor($identity_id);
     }
 
+    public static function canCreateGroupIdentities($identity_id) {
+        return self::isGroupIdentityCreator($identity_id);
+    }
+
     public static function canViewCourse($identity_id, Courses $course, Groups $group) {
         if (!Authorization::isCourseAdmin($identity_id, $course) &&
             !Authorization::isGroupMember($identity_id, $group)) {
@@ -212,6 +225,18 @@ class Authorization {
         );
     }
 
+    public static function isGroupIdentityCreator($identity_id) {
+        if (self::$group_identity_creator == null) {
+            self::$group_identity_creator = GroupsDAO::findByAlias(
+                Authorization::IDENTITY_CREATOR_GROUP_ALIAS
+            );
+        }
+        return Authorization::isGroupMember(
+            $identity_id,
+            self::$group_identity_creator
+        );
+    }
+
     public static function isSupportTeamMember($identity_id) {
         if (self::$support_group == null) {
             self::$support_group = GroupsDAO::findByAlias(
@@ -274,6 +299,7 @@ class Authorization {
         self::$quality_reviewer_group = null;
         self::$mentor_group = null;
         self::$support_group = null;
+        self::$group_identity_creator = null;
     }
 
     public static function canSubmitToProblemset($identity_id, $problemset) {

--- a/frontend/server/libs/Validators.php
+++ b/frontend/server/libs/Validators.php
@@ -127,6 +127,24 @@ class Validators {
     }
 
     /**
+     * Enforces username identity requirements
+     *
+     * @param string $parameter
+     * @param string $parameterName
+     * @param boolean $required
+     * @throws InvalidParameterException
+     */
+    public static function isValidUsernameIdentity($parameter, $parameterName, $required = true) {
+        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+
+        if ($isPresent && preg_match('/[^a-zA-Z0-9_.:-]/', $parameter)) {
+            throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
+        }
+
+        Validators::isStringOfMinLength($parameter, $parameterName, 2);
+    }
+
+    /**
      *
      * @param date $parameter
      * @param string $parameterName

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Tests for apiCreate and apiBulkCreate in IdentityController
+ *
+ * @author juan.pablo
+ */
+require_once 'libs/FileHandler.php';
+
+class IdentityCreateTest extends OmegaupTestCase {
+    /**
+     * Basic test for users from identity creator group
+     */
+    public function testIdentityHasContestOrganizerRole() {
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creator_identity = IdentitiesDAO::getByPK($creator->main_identity_id);
+        $mentor = UserFactory::createMentorIdentity();
+        $mentor_identity = IdentitiesDAO::getByPK($mentor->main_identity_id);
+
+        $is_creator_member = Authorization::isGroupIdentityCreator($creator_identity->identity_id);
+        // Asserting that user belongs to the  identity creator group
+        $this->assertEquals(1, $is_creator_member);
+
+        $is_creator_member = Authorization::isGroupIdentityCreator($mentor_identity->identity_id);
+        // Asserting that user doesn't belong to the identity creator group
+        $this->assertNotEquals(1, $is_creator_member);
+    }
+
+    /**
+     * Basic test for creating a single identity
+     */
+    public function testCreateSingleIdentity() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+
+        $identityName = substr(Utils::CreateRandomString(), -10);
+        // Call api using identity creator group member
+        IdentityController::apiCreate(new Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'username' => "{$group['group']->alias}:{$identityName}",
+            'name' => $identityName,
+            'password' => Utils::CreateRandomString(),
+            'country_id' => 'MX',
+            'state_id' => 'QUE',
+            'gender' => 'male',
+            'school_name' => Utils::CreateRandomString(),
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $response = GroupController::apiMembers(new Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $this->assertEquals(1, count($response['identities']));
+    }
+
+    /**
+     * Test for creating an identity with wrong group
+     * @throws InvalidDatabaseOperationException
+     */
+    public function testCreateIdentityWithWrongGroup() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+        $wrongGroupAlias = 'wrongGroupAlias';
+        $identityName = substr(Utils::CreateRandomString(), -10);
+        // Call api using identity creator group member
+        try {
+            $response = IdentityController::apiCreate(new Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'username' => "{$wrongGroupAlias}:{$identityName}",
+                'name' => $identityName,
+                'password' => Utils::CreateRandomString(),
+                'country_id' => 'MX',
+                'state_id' => 'QUE',
+                'gender' => 'male',
+                'school_name' => Utils::CreateRandomString(),
+                'group_alias' => $group['group']->alias,
+            ]));
+        } catch (InvalidDatabaseOperationException $e) {
+            // OK.
+        }
+    }
+
+    /**
+     * Test for creating an identity with wrong username
+     */
+    public function testCreateIdentityWithWrongUsername() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+        $wrongIdentityName = 'wrong:username';
+        // Call api using identity creator group member
+        try {
+            $response = IdentityController::apiCreate(new Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'username' => "{$group['group']->alias}:{$wrongIdentityName}",
+                'name' => $wrongIdentityName,
+                'password' => Utils::CreateRandomString(),
+                'country_id' => 'MX',
+                'state_id' => 'QUE',
+                'gender' => 'male',
+                'school_name' => Utils::CreateRandomString(),
+                'group_alias' => $group['group']->alias,
+            ]));
+            $this->fail('Identity should not be created because of the wrong username (Use of [:] is not allowed)');
+        } catch (InvalidDatabaseOperationException $e) {
+            // OK.
+        }
+        $wrongIdentityName = 'wrongUsername';
+        try {
+            $response = IdentityController::apiCreate(new Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'username' => $wrongIdentityName,
+                'name' => $wrongIdentityName,
+                'password' => Utils::CreateRandomString(),
+                'country_id' => 'MX',
+                'state_id' => 'QUE',
+                'gender' => 'male',
+                'school_name' => Utils::CreateRandomString(),
+                'group_alias' => $group['group']->alias,
+            ]));
+            $this->fail('Identity should not be created because of the wrong username (Username needs inlclude group_alias)');
+        } catch (InvalidDatabaseOperationException $e) {
+            // OK.
+        }
+    }
+
+    /**
+     * Basic test for uploading csv file
+     */
+    public function testUploadCsvFile() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+
+        // Call api using identity creator group member
+        $response = IdentityController::apiBulkCreate(new Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => self::getCsvData('identities.csv', $group['group']->alias),
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $response = GroupController::apiMembers(new Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $this->assertEquals(5, count($response['identities']));
+    }
+
+    /**
+     * Test for uploading csv file with duplicated usernames
+     * @throws DuplicatedEntryInDatabaseException
+     */
+    public function testUploadCsvFileWithDuplicatedUsernames() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+
+        try {
+            // Call api using identity creator group member
+            $response = IdentityController::apiBulkCreate(new Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'identities' => self::getCsvData('duplicated_identities.csv', $group['group']->alias),
+                'group_alias' => $group['group']->alias,
+            ]));
+        } catch (DuplicatedEntryInDatabaseException $e) {
+            // OK.
+        }
+    }
+
+    /**
+     * Test for uploading csv file with wrong country_id
+     * @throws InvalidDatabaseOperationException
+     */
+    public function testUploadCsvFileWithWrongCountryId() {
+        // Identity creator group member will upload csv file
+        $creator = UserFactory::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup($creator, null, null, null, $creatorLogin);
+
+        try {
+            // Call api using identity creator group team member
+            $response = IdentityController::apiBulkCreate(new Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'identities' => self::getCsvData('identities_wrong_country_id.csv', $group['group']->alias),
+                'group_alias' => $group['group']->alias,
+            ]));
+        } catch (InvalidDatabaseOperationException $e) {
+            // OK.
+        }
+    }
+
+    /**
+     * @param $file
+     * @return $csv_data
+     */
+    private static function getCsvData($file, $group_alias) {
+        $row = 0;
+        $identities = [];
+        $headers = [];
+        $path_file = OMEGAUP_RESOURCES_ROOT . $file;
+        if (($handle = fopen($path_file, 'r')) == false) {
+            throw new InvalidParameterException('parameterInvalid', 'identities');
+        }
+        while (($data = fgetcsv($handle, 1000, ',')) != false) {
+            if ($row === 0) {
+                $headers = $data;
+            } else {
+                $identity = [];
+                $identity['username'] = "{$group_alias}:{$data[0]}";
+                $identity['name'] = $data[1];
+                $identity['country_id'] = $data[2];
+                $identity['state_id'] = $data[3];
+                $identity['gender'] = $data[4];
+                $identity['school_name'] = $data[5];
+                $identity['password'] = Utils::CreateRandomString();
+                array_push($identities, $identity);
+            }
+            $row++;
+        }
+        fclose($handle);
+        return $identities;
+    }
+}

--- a/frontend/tests/factories/UserFactory.php
+++ b/frontend/tests/factories/UserFactory.php
@@ -217,6 +217,23 @@ class UserFactory {
     }
 
     /**
+     * Creates a new user with contest organizer role
+     *
+     * @param string $username
+     * @param string $password
+     * @param string $email
+     * @return User
+     */
+    public static function createGroupIdentityCreator($params = null) {
+        $user = self::createUser($params);
+        $identity = IdentitiesDAO::getByPK($user->main_identity_id);
+
+        self::addGroupIdentityCreator($identity);
+
+        return $user;
+    }
+
+    /**
      * Adds a system role to the user.
      *
      * @param Users $user
@@ -259,6 +276,22 @@ class UserFactory {
         GroupsIdentitiesDao::save(new GroupsIdentities([
             'identity_id' => $identity->identity_id,
             'group_id' => $support_group->group_id,
+        ]));
+    }
+
+    /**
+     * Adds group identity creator
+     *
+     * @param Identities $identity
+     */
+    public static function addGroupIdentityCreator(Identities $identity) {
+        $groupIdentityCreator = GroupsDAO::findByAlias(
+            Authorization::IDENTITY_CREATOR_GROUP_ALIAS
+        );
+
+        GroupsIdentitiesDao::save(new GroupsIdentities([
+            'identity_id' => $identity->identity_id,
+            'group_id' => $groupIdentityCreator->group_id,
         ]));
     }
 

--- a/frontend/tests/resources/duplicated_identities.csv
+++ b/frontend/tests/resources/duplicated_identities.csv
@@ -1,0 +1,6 @@
+username,name,country_id,state_id,gender,school_name
+identity_1,Identity One,MX,AGU,male,School Group
+identity_2,Identity Two,MX,BCN,male,School Group
+identity_3,Identity Three,MX,BCS,female,School Group
+identity_3,Identity Four,MX,CHH,male,School Group
+identity_5,Identity Five,MX,CHP,female,School Group

--- a/frontend/tests/resources/identities.csv
+++ b/frontend/tests/resources/identities.csv
@@ -1,0 +1,6 @@
+﻿username,name,country_id,state_id,gender,school_name
+identity_1,Identity One,MX,AGU,male,School Group
+identity_2,Identity Two,MX,BCN,male,School Group
+identity_3,Identity Three,MX,BCS,female,School Group
+identity_4,Identity Four,MX,CHH,male,School Group
+identity_5,Identity Five,MX,CHP,female,School Group

--- a/frontend/tests/resources/identities_wrong_country_id.csv
+++ b/frontend/tests/resources/identities_wrong_country_id.csv
@@ -1,0 +1,6 @@
+username,name,country_id,state_id,gender,school_name
+identity_1,Identity One,MX,AGU,male,School Group
+identity_2,Identity Two,ZZ,BCN,male,School Group
+identity_3,Identity Three,MX,BCS,female,School Group
+identity_4,Identity Four,MX,CHH,male,School Group
+identity_5,Identity Five,MX,CHP,female,School Group


### PR DESCRIPTION
# Descripción

Continuación del PR [#2140](https://github.com/omegaup/omegaup/pull/2140), donde se agregan las pruebas de las `API's` de cargar identidades

Fixes: [#1910](https://github.com/omegaup/omegaup/issues/1910)

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
