### PR TITLE
Dejando de enviar Request como parámetro en funciones de CourseController

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1041,9 +1041,8 @@ class UserController extends Controller {
                 throw new ForbiddenAccessException();
             }
             $keys = [
-                'OMIROO-19' => 400,
-                'OMIPROO-19' => 50,
-                'OMISROO-19' => 60,
+                'OMIPROO-19' => 40,
+                'OMISROO-19' => 90,
             ];
         } elseif ($r['contest_type'] == 'TEBAEV') {
             if ($r['current_user']->username != 'lacj20'

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -238,6 +238,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         // Testing with an intermediate day of the month
         $timestampTest = Time::get();
         $dateTest = date('Y-m-15', $timestampTest);
+        $timestampTest = strtotime($dateTest);
         $canChooseCoder = Authorization::canChooseCoder($timestampTest);
         $this->assertFalse($canChooseCoder);
 

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -64,6 +64,7 @@ class CoursesFactory {
         // Create the course
         $courseFactoryResult = self::createCourse($admin, $adminLogin, $public, $requestsUserInformation, $showScoreboard);
         $courseAlias = $courseFactoryResult['course_alias'];
+        $course = CoursesDAO::getByAlias($courseAlias);
 
         // Create the assignment
         $assignmentAlias = Utils::CreateRandomString();
@@ -77,9 +78,9 @@ class CoursesFactory {
             'finish_time' => Utils::GetPhpUnixTimestamp() + 120,
             'course_alias' => $courseAlias,
             'assignment_type' => 'homework',
+            'course' => $course,
         ]);
         $assignmentResult = CourseController::apiCreateAssignment($r);
-        $course = CoursesDAO::getByAlias($courseAlias);
         $assignment = AssignmentsDAO::getByAliasAndCourse($assignmentAlias, $course->course_id);
         return [
             'course_alias' => $courseAlias,


### PR DESCRIPTION
# Descripción

Continuación de https://github.com/omegaup/omegaup/pull/2235

Se agrega un refactor para dejar de enviar `Request` como parámetro dentro de las funciones de `CourseController`.

Segunda parte de: https://github.com/omegaup/omegaup/issues/2144

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
